### PR TITLE
CVC-1062 Nonce store lock by key introduced

### DIFF
--- a/src/support/nonce/manager.js
+++ b/src/support/nonce/manager.js
@@ -68,48 +68,65 @@ class NonceManager {
   async getNonceForAccount(address) {
     logger.debug(`Requesting nonce for address ${address}`);
 
-    // Retrieve stored nonces for the provided account.
-    let nonces = await this.store.get(address);
-    // Retrieve current transaction count and transaction pool state for the provided account.
-    const [txCount, { pending, queued }] = await Promise.all([
-      this.getTransactionCount(address),
-      this.inspectTxPool(address)
-    ]);
-
-    // Keep nonces which are not mined yet
-    // and release nonces which values are below the account tx count (i.e. lowest possible value).
-    nonces = _.pickBy(nonces, (value, nonce) => {
-      if (nonce >= txCount) return true;
-      logger.debug(`Account '${address}', nonce released: ${Number(nonce)}`);
-      return false;
-    });
-
-    // Get all known transactions by combining local cache with data from tx pool.
-    const knownTransactions = _.assign({}, nonces, pending, queued);
-
-    // Get all used nonces.
-    const usedNonces = _.keys(knownTransactions);
-    if (usedNonces.length) {
-      logger.debug(`Account '${address}', used nonces: ${usedNonces.join(', ')}`);
+    // First acquire lock to avoid race conditions when modifying the list of used nonces
+    try {
+      await this.store.lock(address);
+    } catch (error) {
+      logger.error(`Error during acquiring lock for ${address}: ${error.message}`, mapError(error));
+      throw error;
     }
 
-    // Calculate max used nonce.
-    const maxUsedNonce = usedNonces.reduce((a, b) => Math.max(a, b), txCount);
+    try {
+      // Retrieve current transaction count and transaction pool state for the provided account.
+      const [txCount, { pending, queued }] = await Promise.all([
+        this.getTransactionCount(address),
+        this.inspectTxPool(address)
+      ]);
 
-    // Go from current tx count value (i.e. lowest possible value) to max known nonce looking for the gaps.
-    let nextNonce = txCount;
-    while (nextNonce <= maxUsedNonce) {
-      // Stop at the first non-used nonce (i.e. first gap).
-      if (!(nextNonce in knownTransactions)) break;
-      // Increment nonce. If no gaps found, return the value next after max used nonce.
-      nextNonce += 1;
+      // Retrieve stored nonces for the provided account.
+      let nonces = await this.store.get(address);
+
+      // Keep nonces which are not mined yet
+      // and release nonces which values are below the account tx count (i.e. lowest possible value).
+      nonces = _.pickBy(nonces, (value, nonce) => {
+        if (nonce >= txCount) return true;
+        logger.debug(`Account '${address}', nonce released: ${Number(nonce)}`);
+        return false;
+      });
+
+      // Get all known transactions by combining local cache with data from tx pool.
+      const knownTransactions = _.assign({}, nonces, pending, queued);
+
+      // Get all used nonces.
+      const usedNonces = _.keys(knownTransactions);
+      if (usedNonces.length) {
+        logger.debug(`Account '${address}', used nonces: ${usedNonces.join(', ')}`);
+      }
+
+      // Calculate max used nonce.
+      const maxUsedNonce = usedNonces.reduce((a, b) => Math.max(a, b), txCount);
+
+      // Go from current tx count value (i.e. lowest possible value) to max known nonce looking for the gaps.
+      let nextNonce = txCount;
+      while (nextNonce <= maxUsedNonce) {
+        // Stop at the first non-used nonce (i.e. first gap).
+        if (!(nextNonce in knownTransactions)) break;
+        // Increment nonce. If no gaps found, return the value next after max used nonce.
+        nextNonce += 1;
+      }
+
+      nonces[nextNonce] = true;
+      // Save the list of assigned nonces and release the lock
+      await this.store.put(address, nonces);
+      logger.debug(`Account '${address}', nonce acquired: ${nextNonce}`);
+
+      return nextNonce;
+    } catch (error) {
+      logger.error(`Error calculating nonce for ${address}: ${error.message}`, mapError(error));
+      // Release the lock for other threads, hope they will not get the same error
+      await this.store.release(address);
+      throw error;
     }
-
-    nonces[nextNonce] = true;
-    await this.store.put(address, nonces);
-    logger.debug(`Account '${address}', nonce acquired: ${nextNonce}`);
-
-    return nextNonce;
   }
 
   /**

--- a/src/support/store/inmemory.js
+++ b/src/support/store/inmemory.js
@@ -1,6 +1,28 @@
+const LOCK_CHECK_INTERVAL = 100; // 100 ms
+const LOCK_ACQUIRE_TIMEOUT = 45 * 1000; // 45 seconds
+const LOCK_TIMEOUT = 1000 * 30; // 30 seconds
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
 module.exports = class InMemory {
   constructor() {
     this.store = {};
+    this.locked = {};
+  }
+
+  async lock(key) {
+    const maxAttempts = Math.floor(LOCK_ACQUIRE_TIMEOUT / LOCK_CHECK_INTERVAL);
+    // Wait until key is availabe for locking
+    for (let attempts = 0; attempts < maxAttempts && this.locked[key]; attempts++) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(LOCK_CHECK_INTERVAL);
+    }
+    // Still locked after all attempts
+    if (this.locked[key]) {
+      throw new Error(`Cannot obtain lock for ${key} after ${LOCK_ACQUIRE_TIMEOUT}ms of ${maxAttempts} attempts`);
+    }
+    // Set a timer to auto-unlock the key in case release or put is never called for whatever reason
+    this.locked[key] = setTimeout(() => this.release(key), LOCK_TIMEOUT);
   }
 
   get(key) {
@@ -9,10 +31,15 @@ module.exports = class InMemory {
 
   put(key, value) {
     this.store[key] = value;
+    this.release(key);
   }
 
-  delete(key) {
-    delete this.store[key];
+  release(key) {
+    if (this.locked[key]) {
+      clearTimeout(this.locked[key]);
+    }
+
+    this.locked[key] = false;
   }
 
   keys() {
@@ -21,5 +48,6 @@ module.exports = class InMemory {
 
   clear() {
     this.store = {};
+    this.keys().map(key => this.release(key));
   }
 };

--- a/test/store.js
+++ b/test/store.js
@@ -1,10 +1,16 @@
-const { expect } = require('chai');
+const chai = require('chai');
 const Store = require('../src/support/store/inmemory');
+const { timeout } = require('../src/support/util');
+
+const TimeoutError = timeout.Error;
+const { expect } = chai;
+chai.use(require('chai-as-promised'));
 
 const key1 = 'abc';
 const key2 = 'def';
 const value1 = { complexObject: { a: 1, b: 2 } };
 const value2 = { complexObject: { a: 3, b: 4 } };
+const timeoutLock = (lockPromise, ms) => timeout(lockPromise, ms, `Cannot acquire lock within ${ms} ms`);
 
 let store;
 
@@ -13,31 +19,44 @@ describe('Store: inmemory.js', () => {
     store = new Store();
   });
 
-  it('lists all keys', () => {
-    store.put(key1, value1);
-    store.put(key2, value2);
+  describe('read and write is available without any locks', () => {
+    it('gets a key', () => {
+      store.put(key1, value1);
 
-    expect(store.keys()).to.contain(key1, key2);
+      expect(store.get(key1)).to.equal(value1);
+    });
+
+    it('clears the store', () => {
+      store.put(key1, value1);
+      store.put(key2, value2);
+      store.clear();
+      // eslint-disable-next-line no-unused-expressions
+      expect(store.keys()).to.be.empty;
+    });
   });
 
-  it('gets a key', () => {
-    store.put(key1, value1);
+  describe('lock', () => {
+    afterEach(() => store.clear());
 
-    expect(store.get(key1)).to.equal(value1);
-  });
+    it('prevents race condition', () =>
+      expect(Promise.all([timeoutLock(store.lock(key1), 300), timeoutLock(store.lock(key1), 300)])).to.be.rejectedWith(
+        TimeoutError
+      ));
 
-  it('deletes a key', () => {
-    store.put(key1, value1);
-    store.delete(key1);
-    // eslint-disable-next-line no-unused-expressions
-    expect(store.get(key1)).to.be.null;
-  });
+    it('locks by key', () => Promise.all([timeoutLock(store.lock(key1), 300), timeoutLock(store.lock(key2), 300)]));
 
-  it('clears the store', () => {
-    store.put(key1, value1);
-    store.put(key2, value2);
-    store.clear();
-    // eslint-disable-next-line no-unused-expressions
-    expect(store.keys()).to.be.empty;
+    it('releases after put', async () => {
+      await store.lock(key1);
+      await expect(timeoutLock(store.lock(key1), 300)).to.be.rejectedWith(TimeoutError);
+      await store.put(key1, value1);
+      await expect(timeoutLock(store.lock(key1), 300)).to.be.fulfilled;
+    });
+
+    it('can release', async () => {
+      await store.lock(key1);
+      await expect(timeoutLock(store.lock(key1), 300)).to.be.rejectedWith(TimeoutError);
+      await store.release(key1);
+      await expect(timeoutLock(store.lock(key1), 300)).to.be.fulfilled;
+    });
   });
 });


### PR DESCRIPTION
Since nonce store methods are called with `await` we have to add lock by key to prevent race conditions in read/write the list of used nonces by an address. The implemented lock is made simple and straightforward to support basic locking and auto-release in case of error. Nonce manager is updated to use the new API.